### PR TITLE
Add Dockerfile, add multi hotspot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+*Dockerfile*
+*docker-compose*
+node_modules
+npm-debug.log

--- a/.env.sample
+++ b/.env.sample
@@ -5,4 +5,4 @@ INFLUX_ORG    = my-org
 INFLUX_TOKEN  = my-token
 
 HELIUM_WALLET  = my-wallet-id
-HELIUM_HOTSPOT = my-helium-hotspot-id
+HELIUM_HOTSPOT = my-hotspot-id1,my-hotspot-id2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:17-alpine
+
+WORKDIR /app
+COPY ["package.json", "package-lock.json*", "./"]
+
+RUN npm install --include=dev --production
+COPY . .
+
+RUN echo "*/30 * * * * /usr/local/bin/node /app/test/test_lambda.js >> /dev/stdout 2>&1" > /etc/cronjob && chmod +x /etc/cronjob
+RUN crontab /etc/cronjob
+
+# Testing
+#CMD ["/usr/local/bin/node", "/app/test/test_lambda.js"]
+
+# Cronjob execution
+CMD ["crond", "-f"]

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const helium = require('./src/helium');
 exports.handler = async (event, context) => {
   console.log('Node ver: ', process.version);
   console.log('Received event:', JSON.stringify(event, null, 2));
+  console.log(`Execution at ${new Date()}`);
 
   Influx.open(); // open influx connection
 

--- a/src/helium.js
+++ b/src/helium.js
@@ -58,7 +58,7 @@ async function processHotspotActivity(hotspotIdentifier, sinceDate) {
   }
 
   if (activities.length == 0) {
-    console.log(`No activities since ${sinceDate.toString()} for hotspot ${hotspotName}`);
+    console.log(`Helium: No activities since ${sinceDate.toString()} for hotspot ${hotspotName}`);
     return;
   }
 

--- a/src/helium.js
+++ b/src/helium.js
@@ -4,7 +4,7 @@ const { Influx, Point } = require('./influx');
 const { default: axios } = require('axios');
 
 // number of hours to go back to fetch hotspot activity
-const HOTSPOT_LOOKBACK_HOURS = 5;
+const HOTSPOT_LOOKBACK_HOURS = 4;
 
 const heliumActivityMeasurement = 'helium_activity';
 

--- a/src/helium.js
+++ b/src/helium.js
@@ -138,12 +138,12 @@ async function processHeliumStats() {
 
 async function processHelium() {
   console.log('Processing helium');
-  let funcList = (process.env.HELIUM_HOTSPOT.split(",")).map(function (hotspot) {
+  let processHotspotsList = (process.env.HELIUM_HOTSPOT.split(",")).map(function (hotspot) {
     return processHotspotActivity(hotspot.trim(), DateTime.local().minus({ hours: HOTSPOT_LOOKBACK_HOURS }));
   });
 
   await Promise.all([
-    ...funcList,
+    ...processHotspotsList,
     processHeliumStats(),
     getPrice(),
   ]);

--- a/src/helium.js
+++ b/src/helium.js
@@ -19,7 +19,7 @@ const activityType = {
 
 async function getPrice() {
   const response = await axios('https://api.coingecko.com/api/v3/simple/price?ids=helium&vs_currencies=USD');
-  console.log('Helium: price: ', response.data);
+  console.log('Helium: price:', response.data);
 
   const point = new Point("helium_price")
     .tag('source', 'CoinGecko')
@@ -33,12 +33,12 @@ async function accountStats() {
   console.log('response :>> ', response);
 }
 
-async function processHotspotActivity(sinceDate) {
+async function processHotspotActivity(hotspotIdentifier, sinceDate) {
   let activities = [];
   let oldestTime = DateTime.now;
-  let hotspot = await helium.hotspots.get(process.env.HELIUM_HOTSPOT);
+  let hotspot = await helium.hotspots.get(hotspotIdentifier);
 
-  console.log('Helium: fetching activity since ', sinceDate.toString());
+  console.log('Helium: fetching activity since', sinceDate.toString(), 'for hotspot', hotspotIdentifier);
   let page = await hotspot.activity.list();
 
   // fetch all activities after specified date
@@ -47,7 +47,7 @@ async function processHotspotActivity(sinceDate) {
     activities.push(...acts);
 
     // console.log(`Page ${page.data.length} vs filtered ${acts.length}`)
-    
+
     // if data was filtered out (timestamp was reached) or no more data, then stop here
     if (acts.length < page.data.length || !page.hasMore) {
       break;
@@ -55,21 +55,23 @@ async function processHotspotActivity(sinceDate) {
 
     page = await page.nextPage();
   }
-  
+
   if (activities.length == 0) {
-    console.log(`No activities since ${sinceDate.toString()}`);
+    console.log(`No activities since ${sinceDate.toString()} for hotspot ${hotspotIdentifier}`);
     return;
   }
 
-  console.log(`Helium: fetched ${activities.length} activities (first ${DateTime.fromSeconds(activities[activities.length-1].time).toString()})`);
+  console.log(`Helium: fetched ${activities.length} activities (first ${DateTime.fromSeconds(activities[activities.length-1].time).toString()}) for hotspot ${hotspotIdentifier}`);
   // activities.map(act => console.log(DateTime.fromSeconds(act.time).toString()));
 
   // convert activities to Influx points
   const points = activities.map(act => {
     const point = new Point(heliumActivityMeasurement)
       .timestamp(DateTime.fromSeconds(act.time).toJSDate())
-      .tag('hotspot', process.env.HELIUM_HOTSPOT);
-    
+      .tag('hotspot', hotspotIdentifier)
+      .tag('name', hotspot.name)
+      .tag('geocode', (hotspot.geocode.shortCity + ", " + hotspot.geocode.shortStreet));
+
     if (act instanceof RewardsV1) {
 
       point.tag('type', 'rewards');
@@ -78,7 +80,7 @@ async function processHotspotActivity(sinceDate) {
 
     } else if (act.type == 'poc_receipts_v1') {
 
-      if (act.path[0].challengee == process.env.HELIUM_HOTSPOT) {
+      if (act.path[0].challengee == hotspotIdentifier) {
         point.tag('type', 'beacon_sent');
         // console.log('Beacon sent: witnesses ', act.path[0].witnesses.length);
       } else {
@@ -122,7 +124,7 @@ async function processHeliumStats() {
   console.log('Helium: collecting network stats');
 
   let point = new Point("helium_stats");
-  point.timestamp(new Date());        // now
+  point.timestamp(new Date());  // now
 
   point.intField('transactions', data.counts.transactions);
   point.intField('challenges', data.counts.challenges);
@@ -135,9 +137,12 @@ async function processHeliumStats() {
 
 async function processHelium() {
   console.log('Processing helium');
+  let funcList = (process.env.HELIUM_HOTSPOT.split(",")).map(function (hotspot) {
+    return processHotspotActivity(hotspot.trim(), DateTime.local().minus({ hours: HOTSPOT_LOOKBACK_HOURS }));
+  });
 
   await Promise.all([
-    processHotspotActivity(DateTime.local().minus({ hours: HOTSPOT_LOOKBACK_HOURS })),
+    ...funcList,
     processHeliumStats(),
     getPrice(),
   ]);


### PR DESCRIPTION
Hey,
this implements #7 and #8. I hope you don't mind they are in one PR.

**Multi-Hotspot:** All changes are backwards compatible to just one hotspot. I've added two arguably helpful tags while at it. Example given.

**Docker:** @ideasman69 In docker-compose.yaml a user might use this image by something like:

```yaml
  helium-poller:
    build:
      context: ./helium-dashboard
    image: helium-dashboard:latest
    depends_on:
      - influxdb
    environment:
      INFLUX_HOST: ${MONITORING_HOST}
      INFLUX_PORT: 8086
      INFLUX_BUCKET: helium
      INFLUX_ORG: myorg
      INFLUX_TOKEN: ${INFLUX_WRITE_TOKEN}
      HELIUM_WALLET: ${HELIUM_WALLET}
      HELIUM_HOTSPOT: ${HELIUM_HOTSPOT}
```

The image has a hardcoded update rate of 30min