### PR TITLE
Add user-agent to avoid 429 errors

### DIFF
--- a/src/helium.js
+++ b/src/helium.js
@@ -120,7 +120,7 @@ async function processHotspotActivity(hotspotIdentifier, sinceDate) {
 }
 
 async function processHeliumStats() {
-  const response = await axios.get('https://api.helium.io/v1/stats');
+  const response = await axios.get('https://api.helium.io/v1/stats',{ headers: { 'User-Agent': 'Helium Dashboard/0.1 (konstk1)'}});
   const data = response.data.data;
   console.log('Helium: collecting network stats');
 


### PR DESCRIPTION
Because of https://docs.helium.com/api/blockchain/introduction/#specify-a-user-agent, I am getting random errors when adding more than one hotspots to the HELIUM_HOTSPOT parameter.

After adding this User Agent (change it to any of your preference), I haven't seen any error. Verified with a list of five hotspots without any problem.

